### PR TITLE
[lotus] Ensure undo data has correct block header hash

### DIFF
--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -2480,7 +2480,7 @@ void Storage::addBlock(PreProcessedBlockPtr ppb, bool saveUndo, unsigned nReserv
             // save the last of the undo info, if in saveUndo mode
             if (undo) {
                 const auto t0 = Util::getTimeNS();
-                undo->hash = BTC::HashRev(rawHeader);
+                undo->hash = BTC::Hash2ByteArrayRev(ppb->header.GetHash());
                 undo->scriptHashes = Util::keySet<decltype (undo->scriptHashes)>(ppb->hashXAggregated);
                 static const QString errPrefix("Error saving undo info to undo db");
 


### PR DESCRIPTION
During reorgs, Fulcrum is failing consistency checks. It seems to
be because the header hash check is failing when loading the undo
data. Sure enough, this hash is stored as a standard BTC header
hash, so this would make sense. This commit fixes that issue --
although more issues may be hiding.